### PR TITLE
Allow omniauth 2.x

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.6", "2.7", "3.1", "3.2"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2"]
 
     steps:
       - uses: actions/checkout@v3

--- a/omniauth-airtable.gemspec
+++ b/omniauth-airtable.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Airtable::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.5'
+  gem.add_dependency 'omniauth', ">= 1.9", "< 3"
   gem.add_dependency 'omniauth-oauth2', '>= 1.4.0', '< 2.0'
   gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'rack-test'


### PR DESCRIPTION
I got a [dependabot alert](https://github.com/miharekar/decent-visualizer/security/dependabot/32) and everything seems compatible, so I think it's OK to relax this.